### PR TITLE
fixing race condition when piping multiple sql scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ GMCFP takes the following arguments...
 - log level - DEFAULT Low. Can be:: 'NONE' - no logging; 'MED'|'M' - Medium logging (no command echo); 'FULL'|'F' - Full logging (commands echoed)
 - database - The database on the host server to use by default
 - force - Boolean indicating if the execution must be continued on query error (defaults to TRUE)
+- serial - Boolean indicating if the sql commands should be run serially or in parallel (defaults to parallel)
 
 ```js
 var gulp = require('gulp');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gulp-mysql-command-file-processor",
+  "version": "1.0.0",
+  "description": "This is a gulp npm module that allows SQL Data Definition Language (DDL) files to be run into a MySql server as part of a controlled release process.",
+  "main": "index.js",
+  "dependencies": {
+    "async": "^2.4.1",
+    "gulp-util": "^3.0.8",
+    "mysql": "^2.13.0",
+    "through2": "^2.0.3"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "homepage": "https://github.com/snapperben/gulp-mysql-command-file-processor#readme"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ function processCommandFile(_username, _password, _host, _port, _verbosity, _dat
             console.log('Starting to process \'' + name + '\'');
         }
         processCommands(name, commandBuffer, dbConnection, verbosity, force, function(){
-            _dbConnection.end(function() {
+            dbConnection.end(function() {
                 console.log('Executed ' + commandBuffer.length + ' commands from file \'' + name + '\'');
                 cb(null, file);
             }); 


### PR DESCRIPTION
I found some strange behavior when trying to run several data scripts in my gulp task
```
 gulp.src('/*.sql').pipe(gmcfp(...))
```
I think because setTimeout is asynchronous, there were some strange race conditions getting created. I saw that SQL commands were getting run _across_ my files (i.e., statement 1 from file 1, then statement 2 from file 2, and so on).

I modified the processCommands function to use async to make sure to run the commandBuffer synchronously. This solved my problem. I was able to confirm that one data script finished before another started.

I also added some other small tweaks to let processCommandFile's callback get called _after_ processCommands finished.